### PR TITLE
0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ dependencies = [
  "serde-env",
  "serde_json",
  "serenity",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "uuid",
 ]
@@ -1479,7 +1479,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2068,11 +2068,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2088,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,9 +2379,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
  "getrandom 0.3.1",
  "rand 0.9.0",
@@ -2391,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02e7142329d47ebfcb5fc40e357b867f971230181e6f78744e52d9325d8f052"
+checksum = "9521621447c21497fac206ffe6e9f642f977c4f82eeba9201055f64884d9cb01"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ serde_json = "1.0.140"
 serenity = { version = "0.12.4", features = ["full"] }
 thiserror = "2.0.12"
 tokio = { version = "1.41.1", features = ["full"] }
-uuid = { version = "1.11.0", features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }
+uuid = { version = "1.15.1", features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,6 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde-env = "0.2.0"
 serde_json = "1.0.140"
 serenity = { version = "0.12.4", features = ["full"] }
-thiserror = "2.0.11"
+thiserror = "2.0.12"
 tokio = { version = "1.41.1", features = ["full"] }
 uuid = { version = "1.11.0", features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ opt-level = 0
 lto = false
 
 [dependencies]
-async-trait = "0.1.83"
+async-trait = "0.1.87"
 dirs = "6.0.0"
 downcast-rs = { version = "2.0.1", features = ["std"] }
 fern = { version = "0.7.0", features = ["colored", "date-based"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ dirs = "6.0.0"
 downcast-rs = { version = "2.0.1", features = ["std"] }
 fern = { version = "0.7.0", features = ["colored", "date-based"] }
 humantime = "2.1.0"
-log = { version = "0.4.20", features = ["serde", "std"] }
+log = { version = "0.4.26", features = ["serde", "std"] }
 rustls = "0.23.23"
 serde = { version = "1.0.215", features = ["derive"] }
 serde-env = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lum_libs"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Torben Schweren"]
 edition = "2024"
 rust-version = "1.85.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ log = { version = "0.4.20", features = ["serde", "std"] }
 rustls = "0.23.23"
 serde = { version = "1.0.215", features = ["derive"] }
 serde-env = "0.2.0"
-serde_json = "1.0.133"
+serde_json = "1.0.140"
 serenity = { version = "0.12.4", features = ["full"] }
 thiserror = "2.0.11"
 tokio = { version = "1.41.1", features = ["full"] }


### PR DESCRIPTION
This pull request includes updates to the `Cargo.toml` file, focusing on version bumps for the package and its dependencies.

Version updates:

* Updated package version from `0.2.0` to `0.2.1` to reflect minor changes.

Dependency updates:

* `async-trait` updated from `0.1.83` to `0.1.87`
* `log` updated from `0.4.20` to `0.4.26`
* `serde_json` updated from `1.0.133` to `1.0.140`
* `thiserror` updated from `2.0.11` to `2.0.12`
* `uuid` updated from `1.11.0` to `1.15.1`