### PR TITLE
Fix CI build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,24 +13,16 @@ jobs:
         include:
           - env: ubuntu-64
             os: ubuntu-latest
-            toolchain: stable-x86_64-unknown-linux-gnu
           - env: macos-64
             os: macos-latest
-            toolchain: stable-x86_64-apple-darwin
           - env: windows-64
             os: windows-latest
-            toolchain: stable-x86_64-pc-windows-msvc
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain ${{ matrix.toolchain }} for ${{ matrix.os }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-      - name: Setup Cargo cache
-        uses: Swatinem/rust-cache@v2
-      - name: Test using ${{ matrix.toolchain }} for ${{ matrix.os }}
+      - name: Setup Rust toolchain for ${{ matrix.os }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Test for ${{ matrix.os }}
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/deploy_prerelease.yml
+++ b/.github/workflows/deploy_prerelease.yml
@@ -12,13 +12,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain stable-x86_64-unknown-linux-gnu for ubuntu-latest
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          override: true
-      - name: Setup Cargo cache
-        uses: Swatinem/rust-cache@v2
+      - name: Setup Rust toolchain for ubuntu-latest
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Package
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -9,11 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain stable-x86_64-unknown-linux-gnu for ubuntu-latest
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          override: true
+      - name: Setup Rust toolchain for ubuntu-latest
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Read source branch version
         id: source_version
         run: echo "version=$(cargo read-manifest | jq -r .version)" >> $GITHUB_OUTPUT
@@ -40,13 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain stable-x86_64-unknown-linux-gnu for ubuntu-latest
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          override: true
-      - name: Setup Cargo cache
-        uses: Swatinem/rust-cache@v2
+      - name: Setup Rust toolchain for ubuntu-latest
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Login to crates.io
         uses: actions-rs/cargo@v1
         with:
@@ -66,13 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain stable-x86_64-unknown-linux-gnu for ubuntu-latest
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable-x86_64-unknown-linux-gnu
-          override: true
-      - name: Setup Cargo cache
-        uses: Swatinem/rust-cache@v2
+      - name: Setup Rust toolchain for ubuntu-latest
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Package
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
This pull request updates the CI/CD workflows to replace the `actions-rs/toolchain` and `Swatinem/rust-cache` actions with the `actions-rust-lang/setup-rust-toolchain` action, as `actions-rs/toolchain` is not working anymore.

### Workflow Updates:

* Updated `.github/workflows/build_and_test.yml` to use `actions-rust-lang/setup-rust-toolchain` for setting up the Rust toolchain, replacing `actions-rs/toolchain` and removing the `Swatinem/rust-cache` action.

* Updated `.github/workflows/deploy_prerelease.yml` to replace `actions-rs/toolchain` and `Swatinem/rust-cache` with `actions-rust-lang/setup-rust-toolchain` for setting up the Rust toolchain.

* Updated `.github/workflows/deploy_release.yml` in multiple steps to replace `actions-rs/toolchain` and `Swatinem/rust-cache` with `actions-rust-lang/setup-rust-toolchain`. [[1]](diffhunk://#diff-85bd47dfba9f57975cf6c7c65e1bbc4c709c0f502d319fb5138506f2e7d2c948L12-R13) [[2]](diffhunk://#diff-85bd47dfba9f57975cf6c7c65e1bbc4c709c0f502d319fb5138506f2e7d2c948L43-R41) [[3]](diffhunk://#diff-85bd47dfba9f57975cf6c7c65e1bbc4c709c0f502d319fb5138506f2e7d2c948L69-R62)