### PR TITLE
Remove re-export of thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,6 @@ dependencies = [
  "serde-env",
  "serde_json",
  "serenity",
- "thiserror 2.0.12",
  "tokio",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,5 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde-env = "0.2.0"
 serde_json = "1.0.140"
 serenity = { version = "0.12.4", features = ["full"] }
-thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full"] }
 uuid = { version = "1.16.0", features = ["v4", "fast-rng", "serde", "macro-diagnostics"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,5 @@ pub use serde;
 pub use serde_env;
 pub use serde_json;
 pub use serenity;
-pub use thiserror;
 pub use tokio;
 pub use uuid;


### PR DESCRIPTION
Re-exporting thiserror is no longer supported by the upstream crate.

See https://github.com/dtolnay/thiserror/issues/386 for more.